### PR TITLE
移除RunMCA的slot参数设置

### DIFF
--- a/single_cell_example/script/pbmc_single_cell_example.R
+++ b/single_cell_example/script/pbmc_single_cell_example.R
@@ -37,7 +37,7 @@ toc()
 tic("Cluster cells and identify markers of cell clusters")
 pbmc <- FindNeighbors(pbmc, dims = 1:10)
 pbmc <- FindClusters(pbmc, resolution = 0.5)
-pbmc <- RunMCA(pbmc, slot = "RNA")
+pbmc <- RunMCA(pbmc)
 cluster_markers <- GetGroupGeneSet(X = pbmc,
                                    group.by = "seurat_clusters",
                                    n.features = 20)


### PR DESCRIPTION
老师，我录屏重新跑例子的时候发现，如果全部装bioconductor 3.18版本的R包，是不需要额外设置这个参数的